### PR TITLE
Encode cba_settings in UTF-8

### DIFF
--- a/cba_settings.sqf
+++ b/cba_settings.sqf
@@ -1,8 +1,8 @@
 /*
-* In dieser Datei können die serverseitigen CBA-Settings überschrieben werden.
+* In dieser Datei kÃ¶nnen die serverseitigen CBA-Settings Ã¼berschrieben werden.
 * Bei mehreren Optionen: Eine un-auskommentiert lassen.
 *
-* Beispiel: 
+* Beispiel:
 * Force Force ace_advanced_fatigue_performanceFactor = 2;
 *
 * Unsere serverseitigen Rosenrudel Settings findet ihr in der @RR_CBASettings.
@@ -13,7 +13,7 @@
 /**************************
   M E D I C S Y S T E M
   Basis 	= Einfach, Bandage, Morphi, Epi
-  IronPack 	= Unser Standard. 
+  IronPack 	= Unser Standard.
   IronPack+ = MilSim, Baby.Endheilung nur im Lazarett. */
 //#define RR_MEDICSYSTEM_BASIS
 #define RR_MEDICSYSTEM_IRONPACK
@@ -29,9 +29,9 @@
 /**********************
   S O N S T I G E S  */
 // ACE Explosives
-force force ace_explosives_explodeOnDefuse = true;		// Können Sprengsätze beim Entschärfen zufällig hochgehen?
-force force ace_explosives_punishNonSpecialists = true;	// Explosionswahrscheinlichkeit bei Nicht-Spezialisten größer?
-force force ace_explosives_requireSpecialist = false;   // Können Sprengsätze nur von Spezialisten entschärft werden?
+force force ace_explosives_explodeOnDefuse = true;		// KÃ¶nnen SprengsÃ¤tze beim EntschÃ¤rfen zufÃ¤llig hochgehen?
+force force ace_explosives_punishNonSpecialists = true;	// Explosionswahrscheinlichkeit bei Nicht-Spezialisten grÃ¶ÃŸer?
+force force ace_explosives_requireSpecialist = false;   // KÃ¶nnen SprengsÃ¤tze nur von Spezialisten entschÃ¤rft werden?
 
 // ACE Feldrationen an? Mehr Infos: https://ace3mod.com/wiki/frameworkx/field-rations-framework.html
 force force acex_field_rations_enabled = false;
@@ -46,6 +46,6 @@ force force acex_field_rations_enabled = false;
 
 
 /*******************************************
- !! AB HIER NICHT LÖSCHEN ODER EDITIEREN !! 
+ !! AB HIER NICHT LÃ–SCHEN ODER EDITIEREN !!
 *******************************************/
 #include "\RR_commons_resources\modKonfigurationsTemplates\CBA_Settings.h"

--- a/cba_settings.sqf
+++ b/cba_settings.sqf
@@ -11,27 +11,27 @@
 
 
 /**************************
-  M E D I C S Y S T E M
-  Basis 	= Einfach, Bandage, Morphi, Epi
-  IronPack 	= Unser Standard.
-  IronPack+ = MilSim, Baby.Endheilung nur im Lazarett. */
+	M E D I C S Y S T E M
+	Basis 	= Einfach, Bandage, Morphi, Epi
+	IronPack 	= Unser Standard.
+	IronPack+ = MilSim, Baby.Endheilung nur im Lazarett. */
 //#define RR_MEDICSYSTEM_BASIS
 #define RR_MEDICSYSTEM_IRONPACK
 // #define RR_MEDICSYSTEM_IRONPACKPLUS
 
 
 /*******************************
-  L O G I S T I K S Y S T E M */
+	L O G I S T I K S Y S T E M */
 #define RR_LOGISTIKSYSTEM_STANDARD
 // #define RR_LOGISTIKSYSTEM_ERWEITERT
 
 
 /**********************
-  S O N S T I G E S  */
+	S O N S T I G E S  */
 // ACE Explosives
-force force ace_explosives_explodeOnDefuse = true;		// Können Sprengsätze beim Entschärfen zufällig hochgehen?
+force force ace_explosives_explodeOnDefuse = true;			// Können Sprengsätze beim Entschärfen zufällig hochgehen?
 force force ace_explosives_punishNonSpecialists = true;	// Explosionswahrscheinlichkeit bei Nicht-Spezialisten größer?
-force force ace_explosives_requireSpecialist = false;   // Können Sprengsätze nur von Spezialisten entschärft werden?
+force force ace_explosives_requireSpecialist = false;		// Können Sprengsätze nur von Spezialisten entschärft werden?
 
 // ACE Feldrationen an? Mehr Infos: https://ace3mod.com/wiki/frameworkx/field-rations-framework.html
 force force acex_field_rations_enabled = false;

--- a/description.ext
+++ b/description.ext
@@ -26,6 +26,6 @@ saving = 0;
 /* Niemals löschen! */
 cba_settings_hasSettingsFile = 1;
 /**************************************************
-         Ab hier Raum für eigenen Inhalt
+		Ab hier Raum für eigenen Inhalt
 **************************************************/
 


### PR DESCRIPTION
`description.ext` was encoded in UTF-8 but the `cba_settings.sqf` in Windows 1252. This caused my text editor to display one of them incorrectly.

I changed `cba_settings.sqf` to be encoded in UTF-8 which is the format I deemed more mainstream.